### PR TITLE
Issue#1: Set credentials for OpenNMS commmunication

### DIFF
--- a/.minion.env
+++ b/.minion.env
@@ -1,8 +1,13 @@
 # Environment variables for OpenNMS Minion connection
 MINION_ID=00000000-0000-0000-0000-deadbeef0001
-MINION_VERSION=develop
 MINION_HOME=/opt/minion
 MINION_LOCATION=vagrant
 MINION_CONFIG=/opt/minion/etc/org.opennms.minion.controller.cfg
+
 OPENNMS_BROKER_URL=tcp://127.0.0.1:61616
 OPENNMS_HTTP_URL=http://127.0.0.1:8980/opennms
+
+OPENNMS_HTTP_USER=minion
+OPENNMS_HTTP_PASS=minion
+OPENNMS_BROKER_USER=minion
+OPENNMS_BROKER_PASS=minion

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,18 @@ LABEL maintainer "Ronny Trommer <ronny@opennms.org>"
 ARG MINION_VERSION=develop
 
 ENV MINION_HOME /opt/minion
-ENV MINION_LOCATION MINION
 ENV MINION_CONFIG /opt/minion/etc/org.opennms.minion.controller.cfg
+
 ENV MINION_ID 00000000-0000-0000-0000-deadbeef0001
+ENV MINION_LOCATION MINION
+
 ENV OPENNMS_BROKER_URL tcp://127.0.0.1:61616
 ENV OPENNMS_HTTP_URL http://127.0.0.1:8980/opennms
+
+ENV OPENNMS_HTTP_USER minion
+ENV OPENNMS_HTTP_PASS minion
+ENV OPENNMS_BROKER_USER minion
+ENV OPENNMS_BROKER_PASS minion
 
 RUN yum -y --setopt=tsflags=nodocs update && \
     rpm -Uvh http://yum.opennms.org/repofiles/opennms-repo-${MINION_VERSION}-rhel7.noarch.rpm && \

--- a/README.md
+++ b/README.md
@@ -55,6 +55,61 @@ To start the Minion and initialize the configuration run with argument `-f`.
 You can login with default user *admin* with password *admin*.
 Please change immediately the default password to a secure password described in the [Install Guide].
 
+## Dealing with Credentials
+
+To communicate with OpenNMS credentials for the message broker and the ReST API are required.
+There are two options to set those credentials to communicate with OpenNMS.
+
+***Option 1***: Set the credentials with an environment variable
+
+It is possible to set communication credentials with environment variables and using the `-c` option for the entrypoint.
+
+```
+docker run --rm -d \
+  -e "MINION_LOCATION=Apex-Office" \
+  -e "OPENNMS_BROKER_URL=tcp://172.20.11.19:61616" \
+  -e "OPENNMS_HTTP_URL=http://172.20.11.19:8980/opennms" \
+  -e "OPENNMS_HTTP_USER=minion" \
+  -e "OPENNMS_HTTP_PASS=minion" \
+  -e "OPENNMS_BROKER_USER=minion" \
+  -e "OPENNMS_BROKER_PASS=minion" \
+  opennms/minion -c
+```
+
+*IMPORTANT:* Be aware these credentials can be exposed in log files and the `docker inspect` command.
+               It is recommended to use an encrypted keystore file which is described in option 2.
+
+***Option 2***: Initialize and use a keystore file 
+
+Credentials for the OpenNMS communication can be stored in an encrypted keystore file `scv.jce`.
+It is possible to start a Minion with a given keystore file by using a file mount into the container like `-v path/to/scv.jce:/opt/minion/etc/scv.jce`
+
+You can initialize a keystore file on your local system using the `-s` option on the Minion container using the interactive mode.
+
+The following example creates a new keystore file `scv.jce` in your current working directory:
+
+```
+docker run --rm -it -v $(pwd):/keystore opennms/minion -s
+
+Enter OpenNMS HTTP username: myminion
+Enter OpenNMS HTTP password:
+Enter OpenNMS Broker username: myminion
+Enter OpenNMS Broker password:
+[main] INFO org.opennms.features.scv.jceks.JCEKSSecureCredentialsVault - No existing keystore found at: {}. Using empty keystore.
+[main] INFO org.opennms.features.scv.jceks.JCEKSSecureCredentialsVault - Loading existing keystore from: scv.jce
+```
+
+The keystore file can be used by mounting the file into the container and start the Minion application with `-f`. 
+
+```
+docker run --rm -d \
+  -e "MINION_LOCATION=Apex-Office" \
+  -e "OPENNMS_BROKER_URL=tcp://172.20.11.19:61616" \
+  -e "OPENNMS_HTTP_URL=http://172.20.11.19:8980/opennms" \
+  -v $(pwd)/scv.jce:/opt/minion/etc/scv.jce \
+  opennms/minion -f 
+```
+
 ## Support and Issues
 
 Please open issues in the [GitHub issue](https://github.com/opennms-forge/docker-minion) section.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,11 @@
-version: '2'
+version: '2.3'
+
 services:
   minion:
     image: opennms/minion:bleeding
     env_file:
       - .minion.env
-    volumes:
-        - /opt/minion/etc
-        - /opt/minion/data
-    command: ["-f"]
+    command: ["-c"]
     healthcheck:
       test: ["CMD", "/opt/minion/bin/client", "ping", "|", "grep", "-Pzo", "\"(?s).*OK.*.OK.*\"", "||", "exit", "1"]
       interval: 10s

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -15,9 +15,41 @@ usage() {
     echo ""
     echo "Docker entry script for OpenNMS Minion service container"
     echo ""
+    echo "-c: Start Minion and use environment credentials to register Minion on OpenNMS."
+    echo "    WARNING: Credentials can be exposed via docker inspect and log files. Please consider to use -s option."
+    echo "-s: Initialize a keystore file with credentials in /keystore/scv.jce."
+    echo "    Mount /keystore to your local system or a volume to save the keystore file."
+    echo "    You can mount the keystore file to ${MINION_HOME}/etc/scv.jce and just use -f to start the Minion."
     echo "-f: Initialize and start OpenNMS Minion in foreground."
     echo "-h: Show this help."
     echo ""
+}
+
+useEnvCredentials(){
+  echo "WARNING: Credentials can be exposed via docker inspect and log files. Please consider to use a keystore file."
+  echo "         You can initialize a keystore file with the -s option."
+  ${MINION_HOME}/bin/scvcli set opennms.http ${OPENNMS_HTTP_USER} ${OPENNMS_HTTP_PASS}
+  ${MINION_HOME}/bin/scvcli set opennms.broker ${OPENNMS_BROKER_USER} ${OPENNMS_BROKER_PASS}
+}
+
+setCredentials() {
+  # Directory to initialize a new keystore file which can be mounted to the local host
+  if [ -z /keystore ]; then
+    mkdir /keystore
+  fi
+
+  read -p "Enter OpenNMS HTTP username: " OPENNMS_HTTP_USER
+  read -s -p "Enter OpenNMS HTTP password: " OPENNMS_HTTP_PASS
+  echo ""
+
+  read -p "Enter OpenNMS Broker username: " OPENNMS_BROKER_USER
+  read -s -p "Enter OpenNMS Broker password: " OPENNMS_BROKER_PASS
+  echo ""
+
+  ${MINION_HOME}/bin/scvcli set opennms.http ${OPENNMS_HTTP_USER} ${OPENNMS_HTTP_PASS}
+  ${MINION_HOME}/bin/scvcli set opennms.broker ${OPENNMS_BROKER_USER} ${OPENNMS_BROKER_PASS}
+
+  cp ${MINION_HOME}/etc/scv.jce /keystore
 }
 
 initConfig() {
@@ -59,8 +91,16 @@ if [[ "${#}" == 0 ]]; then
 fi
 
 # Evaluate arguments for build script.
-while getopts fhis flag; do
+while getopts csfh flag; do
     case ${flag} in
+        c)
+            useEnvCredentials
+            initConfig
+            start
+            ;;
+        s)
+            setCredentials
+            ;;
         f)
             initConfig
             start

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -31,16 +31,17 @@ initConfig() {
         # Expose Karaf Shell
         sed -i "s,sshHost = 127.0.0.1,sshHost = 0.0.0.0," ${MINION_HOME}/etc/org.apache.karaf.shell.cfg
 
-        # Set Minion location and connection to OpenNMS instance
-        sed -i "s,location = MINION,location = ${MINION_LOCATION}," ${MINION_CONFIG}
-        echo "broker-url = ${OPENNMS_BROKER_URL}" >> ${MINION_CONFIG}
-        echo "http-url = ${OPENNMS_HTTP_URL}" >> ${MINION_CONFIG}
-        echo "id = ${MINION_ID}" >> ${MINION_CONFIG}
-        echo "Configured $(date)" > ${MINION_HOME}/etc/configured
-
         # Expose the RMI registry and server
         sed -i "s,rmiRegistryHost.*,rmiRegistryHost=0.0.0.0,g" ${MINION_HOME}/etc/org.apache.karaf.management.cfg
         sed -i "s,rmiServerHost.*,rmiServerHost=0.0.0.0,g" ${MINION_HOME}/etc/org.apache.karaf.management.cfg
+
+        # Set Minion location and connection to OpenNMS instance
+        echo "location = ${MINION_LOCATION}" > ${MINION_CONFIG}
+        echo "id = ${MINION_ID}" >> ${MINION_CONFIG}
+        echo "broker-url = ${OPENNMS_BROKER_URL}" >> ${MINION_CONFIG}
+        echo "http-url = ${OPENNMS_HTTP_URL}" >> ${MINION_CONFIG}
+
+        echo "Configured $(date)" > ${MINION_HOME}/etc/configured
     else
         echo "OpenNMS Minion is already configured, skipped."
     fi


### PR DESCRIPTION
Enhanced the entrypoint file to provide two options to set credentials. The first option allows to use credentials for the Broker and HTTP communication via environment variables using the -c option. For the reason those credentials can be exposed in log files and docker inspect a second option to use a keystore file. Added a -s command line option to give users the possibility to initialize a keystore file in interactive mode, which can be mounted into the container. This way no credentials are exposed while running the container.

Added also minor issues to ensure configuration file is always created.

Resolve #1 