### PR TITLE
Run as non-root by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,11 @@ RUN yum -y --setopt=tsflags=nodocs update && \
     rpm --import http://yum.opennms.org/OPENNMS-GPG-KEY && \
     yum -y install opennms-minion && \
     yum clean all && \
-    rm -rf /var/cache/yum
+    rm -rf /var/cache/yum && \
+    chown minion:minion /opt/minion && \
+    sed -r -i '/RUNAS/s/.*/export RUNAS=minion/' /etc/sysconfig/minion
+
+USER minion
 
 COPY ./docker-entrypoint.sh /
 


### PR DESCRIPTION
Minion will run as root by default but it was designed to run as non-root, assuming the kernel is recent enough to allow the execution of ICMP requests for unprivileged users.

To run docker, you also need a recent kernel version, so it is entirely possible to be able to run Minion as non-root. Although, this might require to add some kernel tuning on the docker machine though, according to Minion's documentation (please let me know if a note on the README.md is required).

This small change makes sure to use the default minion user as the owner of the process to run minion as non-root.