### PR TITLE
Fix RMI host changes to avoid conflicts with serviceUrl.

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -116,11 +116,11 @@ initConfig() {
     if [ ! -f ${MINION_HOME}/etc/configured} ]; then
 
         # Expose Karaf Shell
-        sed -i "s,sshHost=127.0.0.1,sshHost=0.0.0.0," ${MINION_HOME}/etc/org.apache.karaf.shell.cfg
+        sed -i "/^sshHost/s/=.*/= 0.0.0.0/" ${MINION_HOME}/etc/org.apache.karaf.shell.cfg
 
         # Expose the RMI registry and server
-        sed -i "s,rmiRegistryHost.*,rmiRegistryHost=0.0.0.0,g" ${MINION_HOME}/etc/org.apache.karaf.management.cfg
-        sed -i "s,rmiServerHost.*,rmiServerHost=0.0.0.0,g" ${MINION_HOME}/etc/org.apache.karaf.management.cfg
+        sed -i "/^rmiRegistryHost/s/=.*/= 0.0.0.0/" ${MINION_HOME}/etc/org.apache.karaf.management.cfg
+        sed -i "/^rmiServerHost/s/=.*/= 0.0.0.0/" ${MINION_HOME}/etc/org.apache.karaf.management.cfg
 
         # Set Minion location and connection to OpenNMS instance
         echo "location = ${MINION_LOCATION}" > ${MINION_CONFIG}


### PR DESCRIPTION
Inside `org.apache.karaf.management.cfg`, only the lines that start with `rmiRegistryHost` and `rmiServerHost` should be updated, otherwise, the `serviceUrl` is accidentally updated leading to exceptions and undesired side effects at runtime (hence this PR).

For consistency, the same logic was applied to `sshHost`.