### PR TITLE
Required changes to run Minion on OpenShift.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,13 +25,13 @@ RUN yum -y --setopt=tsflags=nodocs update && \
     yum clean all && \
     rm -rf /var/cache/yum && \
     chown minion:minion /opt/minion && \
-    sed -r -i '/RUNAS/s/.*/export RUNAS=minion/' /etc/sysconfig/minion
+    sed -r -i '/RUNAS/s/.*/export RUNAS=minion/' /etc/sysconfig/minion && \
+    chgrp -R 0 /opt/minion && \
+    chmod -R g=u /opt/minion
 
-USER minion
+USER 999
 
 COPY ./docker-entrypoint.sh /
-
-VOLUME [ "/opt/minion/etc", "/opt/minion/etc/featuresBoot.d", "/opt/minion/data" ]
 
 LABEL license="AGPLv3" \
       org.opennms.horizon.version="${MINION_VERSION}" \
@@ -40,13 +40,13 @@ LABEL license="AGPLv3" \
 
 ENTRYPOINT [ "/docker-entrypoint.sh" ]
 
-CMD [ "-h" ]
+CMD [ "-f" ]
 
 ##------------------------------------------------------------------------------
 ## EXPOSED PORTS
 ##------------------------------------------------------------------------------
 ## -- OpenNMS KARAF SSH   8201/TCP
 ## -- OpenNMS JMX        18980/TCP
-## -- SNMP Trapd           162/UDP
-## -- Syslog               514/UDP
-EXPOSE 8201 18980 162/udp 514/udp
+## -- SNMP Trapd          1162/UDP
+## -- Syslog              1514/UDP
+EXPOSE 8201 1162/udp 1514/udp

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -155,7 +155,7 @@ applyOverlayConfig() {
 
 start() {
     cd ${MINION_HOME}/bin
-    ./karaf server
+    exec ./karaf server
 }
 
 # Evaluate arguments for build script.


### PR DESCRIPTION
As described [here](https://docs.okd.io/latest/creating_images/guidelines.html#openshift-specific-guidelines), there are multiple changes required on the `Dockerfile`, in order to run Docker images on OpenShift.

The core changes are:

1) Image must run as non-root.
2) Image must run with an arbitrary UID, which requires permission on the runtime folders/files so OpenShift can read/write files with this arbitrary UID.
3) The `USER` entry on the `Dockerfile` should use the numeric UID, not the name of the user.
4) Volumes should only be declared when they are mandatory, not when they are optional.
5) The default command should point to a running state by default, to avoid redeploy the image once created. This is a special use case when the OpenShift UI is used to deploy the application.
6) Make sure that the main process runs at PID 1, and it properly process SIGTERM for graceful shutdowns.